### PR TITLE
Get available voices on page load

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,11 @@
             $(".loader").fadeOut("slow");
         })
     </script>
+    <script type="text/javascript">
+      // This call is to ensure that voices are loaded by the time
+      // we try to synthesize an utterance.
+      speechSynthesis.getVoices();
+    </script>
 </head>
 
 


### PR DESCRIPTION
Since `speechSynthesis.getVoices` is asynchronous, the list of voices is still empty by the time we synthesize our first utterance in `makeWav`. By calling it on page load, we ensure the voices are available in time.

This fixes the issue on both Chrome and Firefox.

Close #125 

(This PR reverts eQualityTime/TheOpenVoiceFactory#134.)